### PR TITLE
stub: add support for different "boards"

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,11 @@ pipenv run pre-commit install -t pre-push
 ### Using TCP port
 
 ```
-.venv/bin/python -m gdb.stub -t microwatt -p 7000
+.venv/bin/python -m gdb.stub -t microwatt -b Genesys2 -p 7000
 ```
 
 * run *pygdbstub* (`-m gdb.stub`)
-* connect to Microwatt on Arty FPGA (`-t microwatt`)
+* connect to Microwatt on Digilent Genesys2 FPGA boatd (`-t microwatt -b Genesys2`)
 * listen on localhost, port 7000 (`-p 7000`)
 
 Then in GDB, connect to stub like:
@@ -55,7 +55,7 @@ Then in GDB, connect to stub like:
 ```
 
 * run *pygdbstub* (`-m gdb.stub`)
-* connect to Microwatt on Arty FPGA (`-t microwatt`)
+* connect to Microwatt on Arty FPGA (`-t microwatt`, Arty is default board for Microwatt target)
 * use stdio to communicate with GDB (default)
 
 ## Debugging communication

--- a/gdb/stub/boards.py
+++ b/gdb/stub/boards.py
@@ -1,0 +1,27 @@
+import urjtag
+
+
+class Board(object):
+    def __init__(self, cable, params=[]):
+        self._cable = cable
+        self._params = params
+
+    def chain(self):
+        """
+        Create and initialize JTAG chain.
+        """
+        cable = self._cable
+        params = self._params
+        chain = urjtag.chain()
+        chain.cable(cable, *params)
+        return chain
+
+
+class Arty(Board):
+    def __init__(self):
+        super().__init__("DigilentNexysVideo")
+
+
+class Genesys2(Board):
+    def __init__(self):
+        super().__init__("DigilentHS1", ["interface=1", "index=0"])


### PR DESCRIPTION
This commit add support for different boards to circumvent (sometimes failing) UrJTAG's detection logic. Two boards are supported:

 * `Arty` (the default for `microwatt` target)
 * `Genesis2`