### PR TITLE
Add support for (poor mans) soft-breakpoints for Microwatt

### DIFF
--- a/gdb/stub/target/__init__.py
+++ b/gdb/stub/target/__init__.py
@@ -1,9 +1,12 @@
+import logging
 from typing import TextIO
 
 from gdb.stub.arch import Arch
 
 
 class Target(object):
+    _logger = logging.getLogger(__name__)
+
     #
     # Methods that must be implemented by individual targets
     #
@@ -19,7 +22,7 @@ class Target(object):
     def register_read(self, regnum: int) -> bytes:
         raise Exception("Should be implemented!")
 
-    def memory_write(self, address: int, length: int, data: bytes) -> None:
+    def memory_write(self, address: int, data: bytes, length: int = None) -> None:
         raise Exception("Should be implemented!")
 
     def stop(self):
@@ -36,6 +39,7 @@ class Target(object):
 
     # Additional methods that may be implemented (but are not
     # mandatory).
+
     def monitor(self, command: str, response: TextIO) -> bool | None:
         """
         Handle `monitor` command, writing response to passed
@@ -48,6 +52,24 @@ class Target(object):
         """
         # By default, monitor commands are not supported.
         return None
+
+    def has_swbreak(self) -> bool:
+        """
+        Return `True` if target support software breakpoints (implemented in
+        stub), `False` otherwise.
+
+        If `True` is returned, target MUST hasattr(target, 'SWBREAK_INSN') and
+        it must be of type `bytes`.
+        """
+        return False
+
+    def hit_swbreak(self) -> bool:
+        """
+        Return `True` is currently "stopped" at one of the software breakpoints,
+        `False` otherwise.
+        """
+        assert self.has_swbreak(), "Called when has_swbreak() reports `False`!"
+        raise Exception("Should be implemented!")
 
     # Common methods
 
@@ -67,6 +89,44 @@ class Target(object):
         """
         self._cpustate.registers.flush()
 
+    def set_swbreak(self, addr, kind):
+        """
+        Plant software breakpoint at given address.
+        """
+        assert self.has_swbreak(), "Called when has_swbreak() reports `False`!"
+        assert hasattr(self, "SWBREAK_INSN"), "SWBREAK_INSN not defined!"
+        assert self.SWBREAK_INSN is not None, "SWBREAK_INSN is None!"
+        assert len(self.SWBREAK_INSN) == kind, "Requested swbreak length mistmatch"
+        assert addr not in self._sw_breakpoints, "Breakpoint already installed!"
+
+        self._sw_breakpoints[addr] = self.memory_read(addr, len(self.SWBREAK_INSN))
+        self.memory_write(addr, self.SWBREAK_INSN)
+        self._logger.debug(
+            "planted sw breakpoint at 0x%016x (original code %s)"
+            % (addr, self._sw_breakpoints[addr].hex())
+        )
+
+    def del_swbreak(self, addr, kind):
+        """
+        Remove previously planted software breakpoint.
+        """
+        assert self.has_swbreak(), "Called when has_swbreak() reports `False`!"
+        assert addr in self._sw_breakpoints, "No swbreak at given address!"
+
+        self.memory_write(addr, self._sw_breakpoints[addr])
+        del self._sw_breakpoints[addr]
+        self._logger.debug("removed sw breakpoint at 0x%016x" % addr)
+
+    def del_swbreaks(self):
+        """
+        Remove ALL previously planted software breakpoint.
+        """
+        for addr, orig in self._sw_breakpoints:
+            self.del_swbreak(addr, len(orig))
+
+    def __init__(self):
+        self._sw_breakpoints = {}
+
     #
     # __enter__ and __exit__ allow to use `with` statement.
     # This is useful for interactive work with target.
@@ -76,12 +136,14 @@ class Target(object):
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb):
+        self.del_swbreaks()
         self.disconnect()
 
     #
     # Ensure that gets disconnected when the object is gone.
     #
     def __del__(self):
+        self.del_swbreaks()
         self.disconnect()
 
 
@@ -101,7 +163,7 @@ class Null(Target):
     def register_read(self, regnum: int) -> bytes:
         return self._cpustate.registers[regnum].get_bytes()
 
-    def memory_write(self, address: int, length: int, data: bytes) -> None:
+    def memory_write(self, address: int, data: bytes, length: int = None) -> None:
         pass
 
     def stop(self):


### PR DESCRIPTION
This PR adds a very hacky support for software breakpoints. It
*DOES NOT* use standard POWER `trap` instruction but rather uses
`b 0` (`0x48000000`) - that is "jump to itself". This effectively causes
the core to get trapped in an endless loop.

Stub then periodically check the status of the core and if it finds out
the code is spinning in one of the planted "breakpoint" instruction,
it stops the core and report `SIGTRAP` back to GDB.