### PR TITLE
Fix Null target missing call to super in init

### DIFF
--- a/gdb/stub/target/__init__.py
+++ b/gdb/stub/target/__init__.py
@@ -149,6 +149,7 @@ class Target(object):
 
 class Null(Target):
     def __init__(self, cpu_state: Arch):
+        super().__init__()
         self._cpustate = cpu_state
 
     def connect(self):


### PR DESCRIPTION

Just a small issue found when trying Null target.
Null target should call super().__init__().