### PR TITLE
Fix memory and register parameter decoding

### DIFF
--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -566,7 +566,7 @@ class Stub(object):
         """
         addr, length_and_data = packet[1:].split(",")
         length, data = length_and_data.split(":")
-        self._target.memory_write(int(addr, 16), int(length, 16), hex2bytes(data))
+        self._target.memory_write(int(addr, 16), hex2bytes(data), int(length, 16))
         self._rsp.send("OK")
 
     def handle_etx(self, packet):

--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -529,6 +529,18 @@ class Stub(object):
         reply = bytes2hex(*[bytes(reg) for reg in self._target.registers])
         self._rsp.send(reply)
 
+    def handle_P(self, packet):
+        """
+        Write register n… with value r…. The register number n is in hexadecimal, and r… contains two hex digits for each byte in the register (target byte order).
+        E.g.
+        Pf=34120000
+        """
+        regnum, value = packet[1:].split("=")
+        regnum = int(regnum, 16)
+        value = hex2bytes(value)
+        self._target.register_write(regnum, value)
+        self._rsp.send("OK")
+
     def handle_m(self, packet):
         """
         `m addr,length`

--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -549,7 +549,7 @@ class Stub(object):
             * `E NN` NN is errno
         """
         addr, length = packet[1:].split(",")
-        reply = self._target.memory_read(int(addr, 16), int(length, 10))
+        reply = self._target.memory_read(int(addr, 16), int(length, 16))
         reply = bytes2hex(reply)
         self._rsp.send(reply)
 
@@ -566,7 +566,7 @@ class Stub(object):
         """
         addr, length_and_data = packet[1:].split(",")
         length, data = length_and_data.split(":")
-        self._target.memory_write(int(addr, 16), int(length, 10), hex2bytes(data))
+        self._target.memory_write(int(addr, 16), int(length, 16), hex2bytes(data))
         self._rsp.send("OK")
 
     def handle_etx(self, packet):

--- a/gdb/stub/target/__init__.py
+++ b/gdb/stub/target/__init__.py
@@ -6,6 +6,7 @@ from gdb.stub.arch import Arch
 
 class Target(object):
     _logger = logging.getLogger(__name__)
+    _cpustate: Arch
 
     #
     # Methods that must be implemented by individual targets
@@ -23,6 +24,9 @@ class Target(object):
         raise Exception("Should be implemented!")
 
     def memory_write(self, address: int, data: bytes, length: int = None) -> None:
+        raise Exception("Should be implemented!")
+
+    def register_write(self, regnum: int, data: bytes) -> None:
         raise Exception("Should be implemented!")
 
     def stop(self):
@@ -163,6 +167,9 @@ class Null(Target):
 
     def register_read(self, regnum: int) -> bytes:
         return self._cpustate.registers[regnum].get_bytes()
+
+    def register_write(self, regnum, data):
+        pass
 
     def memory_write(self, address: int, data: bytes, length: int = None) -> None:
         pass

--- a/gdb/stub/target/microwatt.py
+++ b/gdb/stub/target/microwatt.py
@@ -255,6 +255,9 @@ class Microwatt(Target):
         value = value[0 : reg.size // 8]
         return value
 
+    def register_write(self, regnum, data):
+        raise Exception("Should be implemented!")
+
     def memory_read(self, addr: int, length: int) -> bytes:
         buflen = round_up(addr + length) - round_down(addr)
         buf = bytearray(buflen)


### PR DESCRIPTION
Summary:

1. Both memory length and register number are encoded in hex string, thus base 16 instead of 10.
This can be seen from GDB debug log when loading a memory dump bin. The
length parameter in below example is 0x7f0, the register number
parameter if 'f'.

```bash
(gdb) set debug remote on
(gdb) restore memdump.bin binary 0x0
Restoring binary file memdump.bin into memory (0x0 to 0x79f3d10)
[remote] Sending packet: $X0,0:#1e
[remote] Received Ack
[remote] Packet received:
[remote] check_binary_download: binary downloading NOT supported by target
[remote] Sending packet: $M0,7f0:00000000090000000000000049000000c00b2140c893214098a421400000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000290000000000000000000000089221400100000000000000000000000000000000000000000000002100000080b6640000000000086e61000000000001000000000000000000000029000000c0912140b0b82140309221400100000000000000010000000000000064657600000000003100000008922140909221400000000007000100807664000200000060012140636f6e736f6c650000000000000000003100000008922140 [3563 bytes omitted]

(gdb) set $pc=0x1234
[remote] Sending packet: $Pf=34120000#7d
```

2. Fix the memory write parameter order, should be `address`, `data` then `length`.
```
    def memory_write(self, address: int, data: bytes, length: int = None) -> None:
        raise Exception("Should be implemented!")
```

3. Added register write support.