### PR TITLE
Print exception message when failed to process command

### DIFF
--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -3,6 +3,7 @@ import io
 import logging
 import os
 import sys
+import traceback
 from argparse import ArgumentParser
 from fcntl import F_GETFL, F_SETFL, fcntl
 from selectors import EVENT_READ, DefaultSelector
@@ -349,9 +350,12 @@ class Stub(object):
                 return True
         try:
             handler(packet)
-        except Exception:
+        except Exception as e:
             # Error when processing the packet
             self._rsp.send("EF1")
+            _logger.error(
+                f"Error processing packet{packet}: {e}\n {traceback.format_exc()}"
+            )
         return True
 
     def check_target(self):
@@ -447,8 +451,11 @@ class Stub(object):
                         self._rsp.send(string2hex(*[response.getvalue()]))
                 else:
                     self._rsp.send("EF0")
-            except Exception:
+            except Exception as e:
                 self._rsp.send("EF1")
+                _logger.error(
+                    f"Error processing packet{packet}: {e}\n {traceback.format_exc()}"
+                )
         else:
             self._rsp.send_unsupported()
 

--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -8,9 +8,7 @@ from fcntl import F_GETFL, F_SETFL, fcntl
 from selectors import EVENT_READ, DefaultSelector
 from socket import SocketIO
 
-from gdb.stub.arch import PowerPC64
-from gdb.stub.target import Null, Target
-from gdb.stub.target.microwatt import Microwatt
+from gdb.stub.target import Target
 
 logging.basicConfig()
 _logger = logging.getLogger(__name__)
@@ -685,6 +683,10 @@ class Stub(object):
 
 
 def main(argv=sys.argv):
+    from gdb.stub.arch import PowerPC64
+    from gdb.stub.target import Null
+    from gdb.stub.target.microwatt import Microwatt
+
     targets = {
         "null-ppc64le": lambda *params: Null(PowerPC64(*params)),
         "microwatt": lambda *params: Microwatt(*params),

--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -445,7 +445,7 @@ class Stub(object):
                 if handled is None:
                     self._rsp.send_unsupported()
                 elif handled is True:
-                    if response.getvalue() is None:
+                    if not response.getvalue():
                         self._rsp.send("OK")
                     else:
                         self._rsp.send(string2hex(*[response.getvalue()]))


### PR DESCRIPTION
Three changes are introduced in this PR.

1. Only import specific board when using it
This avoid loading the board and target during import package.

2. Add error message to stub when exception happened
It makes debugging the stub more easier.

3. Fix monitor command failed to reply
The `io.StringIO().getvalue` returns type of `str`. In case of empty response, the return value is `''`, which is not `None`.
An empty response to GDB is regarded as command not supported.

