### PR TITLE
Add SocketIOStub class for easily setup

### DIFF
--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -690,6 +690,13 @@ class SocketIOStub(Stub):
 
         listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
 
+        # Reuse address so we don't have to wait for socket to be
+        # close before we can bind to the port again
+        listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
+        # No delay in sending packets, to speed up communication
+        listener.setsockopt(socket.IPPROTO_TCP, socket.TCP_NODELAY, 1)
+
         # Wait for client to connect...
         try:
             listener.bind(("localhost", port))

--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -684,6 +684,45 @@ class Stub(object):
             self._rsp.send_unsupported()
 
 
+class SocketIOStub(Stub):
+    def __init__(self, target: Target, port: int = 1234):
+        import socket
+
+        listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+
+        # Wait for client to connect...
+        try:
+            listener.bind(("localhost", port))
+            self._logger.info(f"Listening on localhost:{port}")
+            listener.listen(1)
+        except socket.error as e:
+            self._logger.error(
+                f"Cannot listen on localhost:{port}: error {e[0]} - {e[1]}"
+            )
+
+        client, addr = listener.accept()
+
+        # Once client connects, stop listening and
+        # start stub on client socket
+        try:
+            self._logger.info(f"Client connected from {addr[0]}:{addr[1]}")
+            listener.close()
+            client_io = socket.SocketIO(client, "rw")
+            super().__init__(target, IOPipe(client_io, client_io))
+            self.client_io = client_io
+        except socket.error as e:
+            self._logger.error(
+                f"Failed to handle client: {port}: error {e[0]} - {e[1]}"
+            )
+
+    def start(self):
+        try:
+            super().start()
+        finally:
+            self.client_io.close()
+        _logger.info("Stub thread stopped")
+
+
 def main(argv=sys.argv):
     targets = {
         "null-ppc64le": lambda *params: Null(PowerPC64(*params)),
@@ -715,6 +754,7 @@ def main(argv=sys.argv):
         sys.excepthook = excepthook
         sys.breakpointhook = breakpointhook
         _logger.setLevel(logging.DEBUG)
+
     if args.board is not None:
         import gdb.stub.boards
 
@@ -726,6 +766,7 @@ def main(argv=sys.argv):
         target = targets[args.target](board())
     else:
         target = targets[args.target]()
+
     if args.port is None:
         #
         # Use stdin/stdout for communication.
@@ -736,38 +777,7 @@ def main(argv=sys.argv):
         _logger.disabled = True
         _logger.propagate = False
         stub = Stub(target)
-        stub.start()
     else:
-        #
-        # Listen on TCP port
-        #
-        from socket import AF_INET, SOCK_STREAM, error, socket
+        stub = SocketIOStub(target, args.port)
 
-        listener = socket(AF_INET, SOCK_STREAM)
-        # Wait for client to connect...
-        try:
-
-            listener.bind(("localhost", args.port))
-            _logger.info(f"Listening on localhost:{args.port}")
-            listener.listen(1)
-        except error as e:
-            _logger.error(
-                f"Cannot listen on localhost:{args.port}: error {e[0]} - {e[1]}"
-            )
-        client, addr = listener.accept()
-
-        # Once client connects, stop listening and
-        # start stub on client socket
-        try:
-            _logger.info(f"Client connected from {addr[0]}:{addr[1]}")
-            listener.close()
-            client_io = SocketIO(client, "rw")
-            try:
-                stub = Stub(target, IOPipe(client_io, client_io))
-                stub.start()
-            finally:
-                client_io.close()
-        except error as e:
-            _logger.error(
-                f"Failed to handle client: {args.port}: error {e[0]} - {e[1]}"
-            )
+    stub.start()

--- a/gdb/stub/__init__.py
+++ b/gdb/stub/__init__.py
@@ -111,31 +111,17 @@ class IOPipe:
             return data
 
 
-Bytes2HexMap = ["%02x" % x for x in range(256)]
-
-
 def bytes2hex(*data: bytes) -> str:
-    hex = io.StringIO()
-    for datum in data:
-        for b in datum:
-            hex.write(Bytes2HexMap[b])
-    return hex.getvalue()
+    return "".join([datum.hex() for datum in data])
 
 
 def string2hex(*data: str) -> str:
     return bytes2hex(*[bytes(datum, "ascii") for datum in data])
 
 
-Hex2BytesMap = {("%02x" % x): x for x in range(256)}
-
-
 def hex2bytes(hex: str) -> bytearray:
     assert len(hex) % 2 == 0
-    data = bytearray(len(hex) // 2)
-    for i in range(len(data)):
-        b = Hex2BytesMap[hex[2 * i : 2 * i + 2]]
-        data[i] = b
-    return data
+    return bytearray.fromhex(hex)
 
 
 def hex2string(hex: str) -> str:


### PR DESCRIPTION
In this PR, the logic to start the stub on TCP port is extracted to a class `SocketIOStub`, so the code can be reused easily.

The two socket options are added in order to improve experience.
1. `SO_REUSEADDR` to make the same address can be reused in case the stub exits unexpectedly.
2. `TCP_NODELAY` to send data immediately. It improves speeds.
