### PR TITLE
Null target read/write memory and register support

### DIFF
--- a/test/test_Stub.py
+++ b/test/test_Stub.py
@@ -39,3 +39,86 @@ def test_g() -> None:
 
     assert len(reply) == 2 + bytes_in_g_packet * 2 + 3
     assert reply.startswith("+$" + ("00" * bytes_in_g_packet) + "#")
+
+
+def test_memory_basic() -> None:
+    # Write 0x1234, read 0x1234, read non-existent memory 0
+    gdb_send = StringIO("$M1234,4:78563412#55+$m1234,4#97+$m0,4#fd+")
+    gdb_recv = StringIO()
+    stub = Stub(target, IOPipe(gdb_send, gdb_recv))
+
+    stub.process1()
+    expect = "+$OK#9a"
+    assert gdb_recv.getvalue() == expect
+
+    stub.process1()
+    expect += "+$78563412#a4"
+    assert gdb_recv.getvalue() == expect
+
+    stub.process1()
+    expect += "+$#00"
+    assert gdb_recv.getvalue() == expect
+
+
+def test_memory_two_region() -> None:
+    # 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+    # 78 56 34 12 xx 12 34 56 78 xx xx xx xx xx xx xx xx
+    # Write 0, 5 with 0x78563412, 0x12345678
+    # Then read 0, 5 and none existent memory 4
+    gdb_send = StringIO("$M0,4:78563412#bb+$M5,4:12345678#c0+$m0,4#fd+$m5,4#02+$m4,4#01+")
+    gdb_recv = StringIO()
+    stub = Stub(target, IOPipe(gdb_send, gdb_recv))
+
+    stub.process1()
+    expect = "+$OK#9a"
+    assert gdb_recv.getvalue() == expect
+
+    # second write
+    stub.process1()
+    expect += "+$OK#9a"
+    assert gdb_recv.getvalue() == expect
+
+    # the first read
+    stub.process1()
+    expect += "+$78563412#a4"
+    assert gdb_recv.getvalue() == expect
+
+    # the second read
+    stub.process1()
+    expect += "+$12345678#a4"
+    assert gdb_recv.getvalue() == expect
+
+    # the non-existent memory read
+    stub.process1()
+    expect += "+$#00"
+    assert gdb_recv.getvalue() == expect
+
+
+def test_memory_region_overlaps() -> None:
+    # 0  1  2  3  4  5  6  7  8  9  a  b  c  d  e  f
+    # 78 56 34 12 xx 12 34 56 78 xx xx xx xx xx xx xx xx
+    #    78 56 34 12 <-- second write
+    # Write 0, 5 with 0x78563412, 0x12345678
+    # Write 1 with 0x12345678
+    gdb_send = StringIO("$M0,4:78563412#bb+$M5,4:12345678#c0+$M1,4:78563412#bc+$m0,9#02+")
+    gdb_recv = StringIO()
+    stub = Stub(target, IOPipe(gdb_send, gdb_recv))
+
+    stub.process1()
+    expect = "+$OK#9a"
+    assert gdb_recv.getvalue() == expect
+
+    # second write
+    stub.process1()
+    expect += "+$OK#9a"
+    assert gdb_recv.getvalue() == expect
+
+    # third write
+    stub.process1()
+    expect += "+$OK#9a"
+    assert gdb_recv.getvalue() == expect
+
+    # Read the whole
+    stub.process1()
+    expect += "+$787856341212345678#b7"
+    assert gdb_recv.getvalue() == expect


### PR DESCRIPTION
Fix #7

This is useful when we have a crash dump of registers and stack memory, fill them to stub so we can use GDB to inspect why it's crashed.

Test:
1. start the stub
`python3 -m gdb.stub -t null-ppc64le -p 1234`
2. start GDB and connect to it
```
(gdb) set architecture powerpc:common64
(gdb) tar rem:1234
(gdb) x/x 0
0x0:    Cannot access memory at address 0x0
(gdb) set *(int*)0 = 0x1234
(gdb) x/x 0
0x0:    0x00001234
(gdb)
(gdb) p/x $r0
$2 = 0x0
(gdb) set $r0=0x12348765
(gdb) p/x $r0
$3 = 0x12348765
(gdb)

```
